### PR TITLE
Add Framelock Enable Checkbox and Control Logic

### DIFF
--- a/src/maindialog.cpp
+++ b/src/maindialog.cpp
@@ -23,6 +23,9 @@
 #include <math.h>
 
 #include <QStorageInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QMessageBox>
 
 #include "config.h"
 #include "maindialog.h"
@@ -235,6 +238,50 @@ void MainDialog::onExit()
             camCheckBoxes[i]->setChecked(false);
 
     close();
+}
+
+
+void MainDialog::onFramelockToggled(bool enabled)
+{
+    int framelockValue = enabled ? 1 : 0;
+    QString action = enabled ? "enabled" : "disabled";
+    
+    QProcess process;
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("DISPLAY", settings.framelockDisplay);
+    process.setProcessEnvironment(env);
+    
+    // Call nvidia-settings directly
+    QStringList arguments;
+    arguments << "-a" << QString("[gpu:0]/FrameLockEnable=%1").arg(framelockValue);
+    process.start("nvidia-settings", arguments);
+    
+    if (!process.waitForFinished(10000)) // Wait up to 10 seconds
+    {
+        ui.framelockCheckBox->blockSignals(true);
+        ui.framelockCheckBox->setChecked(!enabled); // Revert checkbox state
+        ui.framelockCheckBox->blockSignals(false);
+        QMessageBox::warning(this, "Framelock Timeout",
+                             QString("The framelock command did not complete within 10 seconds."));
+        return;
+    }
+    
+    int exitCode = process.exitCode();
+    if (exitCode != 0)
+    {
+        ui.framelockCheckBox->blockSignals(true);
+        ui.framelockCheckBox->setChecked(!enabled); // Revert checkbox state
+        ui.framelockCheckBox->blockSignals(false);
+        QString errorOutput = process.readAllStandardError();
+        QMessageBox::warning(this, "Framelock Error",
+                             QString("Failed to %1 framelock (exit code %2).\n\nError output:\n%3")
+                             .arg(action).arg(exitCode).arg(errorOutput));
+        return;
+    }
+    
+    // Success - checkbox state is already set
+    // Optionally show a brief status message in the status bar
+    statusLeft->setText(QString("Framelock %1").arg(action));
 }
 
 

--- a/src/maindialog.cpp
+++ b/src/maindialog.cpp
@@ -268,7 +268,7 @@ void MainDialog::disableFramelockOnStartup()
     
     // Disable framelock silently on startup
     QStringList arguments;
-    arguments << "-a" << "[gpu:0]/FrameLockEnable=0";
+    arguments << "-a" << QString("%1/FrameLockEnable=0").arg(miscSettings.framelockGpuTarget);
     process.start("nvidia-settings", arguments);
     process.waitForFinished(5000); // Wait up to 5 seconds, but don't show errors
     
@@ -292,7 +292,7 @@ void MainDialog::onFramelockToggled(bool enabled)
     
     // Call nvidia-settings directly
     QStringList arguments;
-    arguments << "-a" << QString("[gpu:0]/FrameLockEnable=%1").arg(framelockValue);
+    arguments << "-a" << QString("%1/FrameLockEnable=%2").arg(miscSettings.framelockGpuTarget).arg(framelockValue);
     process.start("nvidia-settings", arguments);
     
     if (!process.waitForFinished(10000)) // Wait up to 10 seconds

--- a/src/maindialog.h
+++ b/src/maindialog.h
@@ -53,6 +53,7 @@ public slots:
     void onStartRec();
     void onStopRec();
     void onExit();
+    void onFramelockToggled(bool enabled);
     void onAudioUpdate(unsigned char* _data);
     void onCamToggled(bool _state);
     void updateDiskSpace();

--- a/src/maindialog.h
+++ b/src/maindialog.h
@@ -63,6 +63,7 @@ public slots:
 
 private:
     void initVideo();
+    void disableFramelockOnStartup();
     Ui::MainDialogClass ui;
 
     // TODO: Replace arrays with std::vectors

--- a/src/maindialog.ui
+++ b/src/maindialog.ui
@@ -292,7 +292,7 @@
      <rect>
       <x>170</x>
       <y>130</y>
-      <width>131</width>
+      <width>150</width>
       <height>27</height>
      </rect>
     </property>

--- a/src/maindialog.ui
+++ b/src/maindialog.ui
@@ -287,6 +287,19 @@
      <string>Cameras</string>
     </property>
    </widget>
+   <widget class="QCheckBox" name="framelockCheckBox">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>130</y>
+      <width>131</width>
+      <height>27</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Enable Framelock</string>
+    </property>
+   </widget>
    <widget class="QPushButton" name="exitButton">
     <property name="geometry">
      <rect>
@@ -353,6 +366,22 @@
    </hints>
   </connection>
   <connection>
+   <sender>framelockCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>MainDialogClass</receiver>
+   <slot>onFramelockToggled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>235</x>
+     <y>993</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>649</x>
+     <y>509</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>exitButton</sender>
    <signal>clicked()</signal>
    <receiver>MainDialogClass</receiver>
@@ -374,6 +403,7 @@
   <slot>onStopRec()</slot>
   <slot>onShutterChanged(int)</slot>
   <slot>onGainChanged(int)</slot>
+  <slot>onFramelockToggled(bool)</slot>
   <slot>onExit()</slot>
  </slots>
 </ui>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -25,6 +25,7 @@
 Settings::Settings()
 {
     settings = new QSettings(ORG_NAME, APP_NAME);
+
     audioSettings.sampRate = settings->value("audio/sampling_rate", 44100).toInt();
     audioSettings.framesPerPeriod = settings->value("audio/frames_per_period", 940).toInt();
     audioSettings.nPeriods = settings->value("audio/num_periods", 10).toInt();
@@ -48,6 +49,7 @@ Settings::~Settings()
     settings->setValue("audio/input_audio_device", audioSettings.inpDev);
     settings->setValue("audio/output_audio_device", audioSettings.outDev);
     settings->setValue("audio/use_speaker_feedback", audioSettings.useFeedback);
+    
     settings->setValue("video/external_trigger_source", miscSettings.externalTriggerSource);
     settings->setValue("misc/data_storage_path", miscSettings.storagePath);
     settings->setValue("misc/low_disk_space_warning_threshold_gb", miscSettings.lowDiskSpaceThreshGB);
@@ -68,6 +70,7 @@ CameraSettings Settings::getCameraSettings(QString _cameraSN)
 
     CameraSettings camSettings;
     QString baseKey = QString("video/camera/") + _cameraSN + "/";
+
     camSettings.shutter = settings->value(baseKey + "shutter", 20).toInt();
     camSettings.gain = settings->value(baseKey + "gain", 10).toInt();
     camSettings.balanceBlue = settings->value(baseKey + "balance_blue", 15).toInt();
@@ -88,6 +91,7 @@ void Settings::setCameraSettings(QString _cameraSN, CameraSettings _camSettings)
     QWriteLocker locker(&rwLock);
 
     QString baseKey = QString("video/camera/") + _cameraSN + "/";
+
     settings->setValue(baseKey + "shutter", _camSettings.shutter);
     settings->setValue(baseKey + "gain", _camSettings.gain);
     settings->setValue(baseKey + "balance_blue", _camSettings.balanceBlue);
@@ -99,7 +103,6 @@ void Settings::setCameraSettings(QString _cameraSN, CameraSettings _camSettings)
     settings->setValue(baseKey + "offset_y", _camSettings.offsetY);
     settings->setValue(baseKey + "color", _camSettings.color);
     settings->setValue(baseKey + "use_external_trigger", _camSettings.useTrigger);
-
 
     settings->sync();
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -112,7 +112,8 @@ struct camera_settings Settings::loadCameraSettings(QString _cameraSN)
     camSettings.offsetx = settings.value(baseKey + "offset_x", 488).toInt();
     camSettings.offsety = settings.value(baseKey + "offset_y", 368).toInt();
     camSettings.color = settings.value(baseKey + "color", true).toBool();
-    camSettings.use_trigger = settings.value(baseKey + "use_trigger", false).toBool();
+    // Use global useExternalTrigger as default if per-camera setting doesn't exist
+    camSettings.use_trigger = settings.value(baseKey + "use_trigger", useExternalTrigger).toBool();
 
     return camSettings;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -32,6 +32,7 @@ Settings::Settings()
     //
 
     // Capture settings
+    useExternalTrigger = settings.value("video/use_external_trigger", false).toBool();
     externalTriggerSource = settings.value("video/external_trigger_source", "Line0").toString();
 
     //---------------------------------------------------------------------
@@ -64,6 +65,9 @@ Settings::Settings()
     // Data storage folder
     storagePath = settings.value("misc/data_storage_path", "/tmp").toString();
     lowDiskSpaceThreshGB = settings.value("misc/low_disk_space_warning_threshold_gb", 5).toDouble();
+    
+    // Framelock display setting
+    framelockDisplay = settings.value("misc/framelock_display", ":2").toString();
 
 }
 
@@ -71,6 +75,7 @@ Settings::~Settings()
 {
     QSettings settings(ORG_NAME, APP_NAME);
 
+    settings.setValue("video/use_external_trigger", useExternalTrigger);
     settings.setValue("video/external_trigger_source", externalTriggerSource);
 
     settings.setValue("audio/sampling_rate", sampRate);
@@ -84,6 +89,7 @@ Settings::~Settings()
 
     settings.setValue("misc/data_storage_path", storagePath);
     settings.setValue("misc/low_disk_space_warning_threshold_gb", lowDiskSpaceThreshGB);
+    settings.setValue("misc/framelock_display", framelockDisplay);
 
     settings.sync();
 }
@@ -106,7 +112,6 @@ struct camera_settings Settings::loadCameraSettings(QString _cameraSN)
     camSettings.offsetx = settings.value(baseKey + "offset_x", 488).toInt();
     camSettings.offsety = settings.value(baseKey + "offset_y", 368).toInt();
     camSettings.color = settings.value(baseKey + "color", true).toBool();
-    camSettings.use_trigger = settings.value(baseKey + "use_external_trigger", false).toBool();
 
     return camSettings;
 }
@@ -127,7 +132,6 @@ void Settings::saveCameraSettings(QString _cameraSN, struct camera_settings _cam
     settings.setValue(baseKey + "offset_x", _camSettings.offsetx);
     settings.setValue(baseKey + "offset_y", _camSettings.offsety);
     settings.setValue(baseKey + "color", _camSettings.color);
-    settings.setValue(baseKey + "use_external_trigger", _camSettings.use_trigger);
 
     settings.sync();
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -112,6 +112,7 @@ struct camera_settings Settings::loadCameraSettings(QString _cameraSN)
     camSettings.offsetx = settings.value(baseKey + "offset_x", 488).toInt();
     camSettings.offsety = settings.value(baseKey + "offset_y", 368).toInt();
     camSettings.color = settings.value(baseKey + "color", true).toBool();
+    camSettings.use_trigger = settings.value(baseKey + "use_trigger", false).toBool();
 
     return camSettings;
 }
@@ -132,6 +133,7 @@ void Settings::saveCameraSettings(QString _cameraSN, struct camera_settings _cam
     settings.setValue(baseKey + "offset_x", _camSettings.offsetx);
     settings.setValue(baseKey + "offset_y", _camSettings.offsety);
     settings.setValue(baseKey + "color", _camSettings.color);
+    settings.setValue(baseKey + "use_trigger", _camSettings.use_trigger);
 
     settings.sync();
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -38,6 +38,7 @@ Settings::Settings()
     miscSettings.storagePath = settings->value("misc/data_storage_path", "/tmp").toString();
     miscSettings.lowDiskSpaceThreshGB = settings->value("misc/low_disk_space_warning_threshold_gb", 5).toDouble();
     miscSettings.framelockDisplay = settings->value("misc/framelock_display", ":2").toString();
+    miscSettings.framelockGpuTarget = settings->value("misc/framelock_gpu_target", "[gpu:0]").toString();
 }
 
 Settings::~Settings()
@@ -54,6 +55,7 @@ Settings::~Settings()
     settings->setValue("misc/data_storage_path", miscSettings.storagePath);
     settings->setValue("misc/low_disk_space_warning_threshold_gb", miscSettings.lowDiskSpaceThreshGB);
     settings->setValue("misc/framelock_display", miscSettings.framelockDisplay);
+    settings->setValue("misc/framelock_gpu_target", miscSettings.framelockGpuTarget);
 
     settings->sync();
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -34,6 +34,7 @@ struct camera_settings {
     int offsetx;
     int offsety;
     bool color;
+    bool use_trigger;
 };
 
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -87,6 +87,8 @@ public:
     // Delete copy constructor and assignment operator
     Settings(const Settings&) = delete;
     Settings& operator=(const Settings&) = delete;
+
+    // Get singleton instance
     static Settings& getInstance();
 
     /*!

--- a/src/settings.h
+++ b/src/settings.h
@@ -34,7 +34,6 @@ struct camera_settings {
     int offsetx;
     int offsety;
     bool color;
-    bool use_trigger;
 };
 
 
@@ -52,6 +51,7 @@ public:
     ~Settings();
 
     // video
+    bool            useExternalTrigger;
     QString         externalTriggerSource;
 
     // audio
@@ -66,6 +66,7 @@ public:
     // misc
     QString         storagePath;
     double          lowDiskSpaceThreshGB;
+    QString         framelockDisplay;
 
     /*!
      * Load camera-specific settings from disk. User camera serial number to

--- a/src/settings.h
+++ b/src/settings.h
@@ -58,6 +58,7 @@ struct MiscSettings
     QString         storagePath;
     double          lowDiskSpaceThreshGB;
     QString         framelockDisplay;
+    QString         framelockGpuTarget;
 };
 
 


### PR DESCRIPTION
- Added "Enable Framelock" checkbox in the main dialog UI (maindialog.ui)
- Implemented onFramelockToggled(bool enabled) slot to handle checkbox state changes
- Added disableFramelockOnStartup() to disable framelock on application startup and sync the checkbox state
- Added framelockDisplay setting in MiscSettings (default: :2) to configure the DISPLAY environment variable for nvidia-settings
- Integrated settings persistence for framelockDisplay in Settings class
- Details:
    - Uses nvidia-settings to control framelock via [gpu:0]/FrameLockEnable
    - Updates status bar with success messages ("Framelock enabled"/"Framelock disabled")